### PR TITLE
Add hardware CTF in events page

### DIFF
--- a/events.html
+++ b/events.html
@@ -130,7 +130,21 @@
 						<a class="boxed-btn3 wow fadeInLeft"  data-wow-duration="1s" data-wow-delay=".2s" href="https://junior.inctf.in/">Visit</a>
 					</div>
 				</div>
-			</div>		
+			</div>
+			<div class="section-top-border">
+				<a href="inctf.in"> <h3 class="mb-30"></h3></a>
+				<div class="row">
+					<div class="col-md-3">
+						<img src="img/elements/d.jpg" alt="" class="img-fluid">
+					</div>
+					<div class="col-md-9 mt-sm-20">
+						<p>Hardware CTF at InCTF is an opportunity to boost the understanding and recognition of hardware security and to add another dimension to traditional CTFs. The CTF is based to demonstrate different
+hardware security concepts and to create a skilled community around hardware, that sparks new conversations and push to make that quantum leap.</p>
+					    <br>
+						<a class="boxed-btn3 wow fadeInLeft"  data-wow-duration="1s" data-wow-delay=".2s" href="https://inctf.in/">Visit</a>
+					</div>
+				</div>
+			</div>
 			<div class="section-top-border">
 				<h3>Event Gallery</h3>
 				<div class="row gallery-item">


### PR DESCRIPTION
* Add hardware CTF in events page

Since Hardware CTF ran with the same logo as InCTF, I have used the same one here